### PR TITLE
Force GCC version

### DIFF
--- a/darknet_ros/CMakeLists.txt
+++ b/darknet_ros/CMakeLists.txt
@@ -3,6 +3,7 @@ project(darknet_ros)
 
 # Set c++11 cmake flags
 set(CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
+set(CMAKE_C_COMPILER /usr/bin/gcc-6 CACHE PATH "" FORCE)
 # set(CMAKE_C_COMPILER "/usr/bin/gcc-5")
 # set(CMAKE_CXX_COMPILER "/usr/bin/g++-5")
 


### PR DESCRIPTION
[Ubuntu 18.04環境でのビルド問題](https://github.com/sbgisen/darknet/issues/1)を解決しました．

---
参考ですが，キャッシュを使わない
```cmake
set(CMAKE_C_COMPILER /usr/bin/gcc-6)
```
では，ビルドできませんでした（CMakeが終了しなくなります）．