### PR TITLE
use cmake variables

### DIFF
--- a/darknet_ros/CMakeLists.txt
+++ b/darknet_ros/CMakeLists.txt
@@ -134,9 +134,9 @@ if (CUDA_FOUND)
     pthread
     stdc++
     cuda
-    cudart
     cublas
-    curand
+    ${CUDA_LIBRARIES}
+    ${CUDA_curand_LIBRARY}
     ${Boost_LIBRARIES}
     ${OpenCV_LIBRARIES}
     ${catkin_LIBRARIES}


### PR DESCRIPTION
close #5 

シンボリックリンクでも解決はできるがcmake側で/usr/local配下のライブラリを参照できるのが好ましいので修正しました。

ubuntu18.04のcmake(3.10.2)では、CUDA_CUBLAS_LIBRARIESを使うとCUDA_cublas_device_LIBRARYでエラーをはくため、使用していません。(3.12.2以降ではエラーが解消されているようです。)