### PR TITLE
Change CUDA version from 10.0 to 10.2

### DIFF
--- a/darknet_ros/CMakeLists.txt
+++ b/darknet_ros/CMakeLists.txt
@@ -3,13 +3,10 @@ project(darknet_ros)
 
 # Set c++11 cmake flags
 set(CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
-set(CMAKE_C_COMPILER /usr/bin/gcc-6 CACHE PATH "" FORCE)
-# set(CMAKE_C_COMPILER "/usr/bin/gcc-5")
-# set(CMAKE_CXX_COMPILER "/usr/bin/g++-5")
 
 # Add definition for CUDA
-add_definitions(-DCUDA_HOME="/usr/local/cuda-10.0")
-add_definitions(-DCUDA_TOOLKIT_ROOT_DIR="/usr/local/cuda-10.0")
+add_definitions(-DCUDA_HOME="/usr/local/cuda-10.2")
+add_definitions(-DCUDA_TOOLKIT_ROOT_DIR="/usr/local/cuda-10.2")
 
 # Define path of darknet folder here.
 find_path(DARKNET_PATH
@@ -83,7 +80,7 @@ include_directories(
 if (CUDA_FOUND)
 
   link_directories(
-    /usr/local/cuda-10.0/lib64
+    /usr/local/cuda-10.2/lib64
   )
 
   cuda_add_library(${PROJECT_NAME}_lib


### PR DESCRIPTION
This commit enables us to build darknet_ros without a specification of gcc version.

It also solve [this issue](https://github.com/sbgisen/darknet/issues/1).